### PR TITLE
Change header comments for new repository

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 /**
  * Swift-Cardinal Object Notation
- * https://github.com/JamesxX/scon
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * Swift-Cardinal Object Notation
- * https://github.com/JamesxX/scon
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -1,6 +1,6 @@
 /**
  * Swift-Cardinal Object Notation
- * https://github.com/JamesxX/scon
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -1,6 +1,6 @@
 /**
  * Swift-Cardinal Object Notation
- * https://github.com/JamesxX/scon
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,6 +1,6 @@
 /**
  * Swift-Cardinal Object Notation
- * https://github.com/JamesxX/scon
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,6 @@
 /**
- * Swift Binary Tag
- * https://github.com/JamesxX/scon
+ * Swift-Cardinal Object Notation
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
  * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,8 +1,8 @@
 /**
- * Swift Binary Tag
- * https://github.com/JamesxX/scon
+ * Swift-Cardinal Object Notation
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) 2016 James R Swift
+ * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,11 @@
+/**
+ * Swift-Cardinal Object Notation
+ * https://github.com/BlueStone-Tech-Enterprises/scon/
+ *
+ * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Licensed under the GNU GPLv3 license.
+ */
+
 var expect = require('chai').expect;
 var scon = require('../index.js');
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
  * Swift-Cardinal Object Notation
  * https://github.com/BlueStone-Tech-Enterprises/scon/
  *
- * Copyright (c) Aritz Beobide-Cardinal, 2016 James R Swift
+ * Copyright (c) BlueStone Technological Enterprises Inc., 2016-2017
  * Licensed under the GNU GPLv3 license.
  */
 


### PR DESCRIPTION
Updated the forgotten heading comments about each file from the previous comment about Swift binary Tag, to Swift Cardinal Object Notation.

Deprecated files such as decode-old.js and encode-old.js were ignored as they are soon to be deleted